### PR TITLE
Fix unranked users cannot request stars.

### DIFF
--- a/src/main/java/com/f2pstarhunt/stars/controller/StarController.java
+++ b/src/main/java/com/f2pstarhunt/stars/controller/StarController.java
@@ -41,7 +41,7 @@ public class StarController {
             @RequestHeader(name = RANK_HEADER, required = false) String rank,
             @RequestParam(name = "status", required = false) String activeOrBackup) {
         boolean includeBackups = "backup".equalsIgnoreCase(activeOrBackup);
-        if (rank == null) {
+        if (includeBackups && rank == null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN.value()).body("You do not have permission to access this resource.");
         }
         return ResponseEntity.ok(starService.getAliveStars(includeBackups));


### PR DESCRIPTION
Only checks the rank header when the request also checks for backup stars.